### PR TITLE
Register events before `login` call to hit "Ready"

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -19,9 +19,9 @@ export class Client extends DiscordClient implements BotClient {
 
     private async initialize(): Promise<void> {
         try {
-            await this.login(configuration.token);
             this.actionManager.initializeCommands(this);
             this.actionManager.initializeEvents(this);
+            await this.login(configuration.token);
         } catch (e) {
             Logger.error(`Could not initialize bot: ${e}`);
         }


### PR DESCRIPTION
Because `login` is called before our events are registered, the `ready`
event triggers before we register it using ActionManager. Reverse the
order of the login call to allow for the bot to be fully initialized
such that all events register, including "Ready".